### PR TITLE
bug fix

### DIFF
--- a/lib/models/post_model.dart
+++ b/lib/models/post_model.dart
@@ -134,7 +134,7 @@ class Post {
     Query<Map<String, dynamic>> firebaseQuery =
         postCollection.orderBy('time', descending: true).limit(20);
     if (popular) {
-      firebaseQuery = firebaseQuery.orderBy('viewCount', descending: true);
+      firebaseQuery = postCollection.orderBy('viewCount', descending: true);
     }
     return firebaseQuery;
   }

--- a/lib/views/posting_page.dart
+++ b/lib/views/posting_page.dart
@@ -24,6 +24,10 @@ class PostListPage extends StatefulWidget {
 }
 
 class _PostListPageState extends State<PostListPage> {
+  //   with AutomaticKeepAliveClientMixin {
+  // @override
+  // bool get wantKeepAlive => true;
+
   Future<void> refreshPosts({bool popular = false}) async {
     // List<Post> posts = await Post.getPostsFromFirebase(popular: popular);
     // List<PostController> _controllers = [];
@@ -53,10 +57,11 @@ class _PostListPageState extends State<PostListPage> {
             return const Center(child: CircularProgressIndicator());
           }
           return ListView.builder(
-            // physics: const AlwaysScrollableScrollPhysics(),
+            // key: PageStorageKey<String>("recenttt"),
             itemCount: snap.data!.size,
             itemBuilder: (BuildContext context, int i) {
               return FutureBuilder<Post>(
+                // key: PageStorageKey<String>("popularrr"),
                 future: Post.fromDocRef(firebaseSnap: snap.data!.docs[i]),
                 builder: (context, snapshot) {
                   if (snapshot.data == null) {
@@ -100,6 +105,7 @@ class _PostListPageState extends State<PostListPage> {
               child: TabBarView(
                 children: [
                   FutureBuilder(
+                      key: PageStorageKey<String>("recent"),
                       future: snapshots,
                       builder:
                           (context, AsyncSnapshot<DocumentSnapshot> snapshot) {
@@ -116,6 +122,7 @@ class _PostListPageState extends State<PostListPage> {
                             popular: false, savedPosts: savedPosts);
                       }),
                   FutureBuilder(
+                      key: PageStorageKey<String>("popular"),
                       future: snapshots,
                       builder:
                           (context, AsyncSnapshot<DocumentSnapshot> snapshot) {


### PR DESCRIPTION
(버그 내용: 탭을 바꾸고 다시 돌아오면 (recent -> popular -> recent) 다시 맨윗글부터 보이게 되는 현상)

진짜 아무리 해도 안 되서 일단 커밋하고 헬프 칩니다,,
FutureBuilder 위젯 안에 key를 설정해주면 scroll position을 기억한대서 해봤는데 작동을 안 합니다. Listview.builder에서 하면 된다는 글들은 많이 봤고, 그리고 FutureBuilder에서는 key가 안 된다고 해서 또 하나 찾은게 AutomaticKeepAliveClientMixin 인데, 이것도 안 되네요.

근데 key 설정을 했을때와 comment처리 하고 돌렸을 때 차이점이 있긴 있습니다. key 설정 했을때, 탭 바꾸고 다시 돌아오면 이전에 위치에 머무르긴 하는데 빠르게 바로 다시 맨 위로 올라가는게 보이긴 합니다. 

https://stackoverflow.com/questions/63805647/why-pagestoragekey-is-not-working-if-the-listview-consists-of-futurebuilder

